### PR TITLE
[messenger] Add android openssl depenedence. Closed #53

### DIFF
--- a/application/application.pro
+++ b/application/application.pro
@@ -26,6 +26,8 @@ qnx: target.path = /tmp/$${TARGET}/bin
 else: unix:!android: target.path = /opt/$${TARGET}/bin
 !isEmpty(target.path): INSTALLS += target
 
+android: include($$(HOME)/Android/Sdk/android_openssl/openssl.pri)
+
 INCLUDEPATH += src
 
 HEADERS += \


### PR DESCRIPTION
The path to openssl may be different depending on the platform.
The readme will describe in detail which path to use.